### PR TITLE
Use library `sniffnet-packet-parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 All `sniffnet-agent` releases with the relative changes are documented in this file.
 
-## [0.1.0] - 2026-xx-xx
+## [0.1.0] - 2026-09-02
 - Initial release of `sniffnet-agent`, a lightweight network flows exporter compatible with Sniffnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 All `sniffnet-agent` releases with the relative changes are documented in this file.
 
 ## [0.1.0] - 2026-xx-xx
-- Initial release of `sniffnet-agent`, an IPFIX exporter compatible with Sniffnet
+- Initial release of `sniffnet-agent`, a lightweight network flows exporter compatible with Sniffnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "bitflags"
@@ -91,9 +91,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -113,14 +113,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -134,6 +134,37 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "errno"
@@ -158,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "etherparse"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac016aaf11dfe643edcd088a166234bfcb72e7f06691abfcf21e9af524037f4"
+checksum = "17304d06addb3283cdc4bd528e42dd95e73c8ee2d6492ffce415e93660885449"
 dependencies = [
  "arrayvec",
 ]
@@ -185,10 +216,12 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jiff"
-version = "0.2.27"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -199,14 +232,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.27"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -242,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -260,9 +303,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pcap"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2eecc2ddc671ec563b5b39f846556aade68a65d1afb14d8fe6b30b0457d75"
+checksum = "d033f537690268aafc38d7ecd5783dfc0a31ac5888da00014f887af16f312a51"
 dependencies = [
  "bitflags",
  "errno",
@@ -358,7 +401,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -372,9 +415,17 @@ name = "sniffnet-agent"
 version = "0.1.0"
 dependencies = [
  "clap",
- "etherparse",
  "jiff",
  "log",
+ "pcap",
+ "sniffnet-packet-parser",
+]
+
+[[package]]
+name = "sniffnet-packet-parser"
+version = "0.1.0"
+dependencies = [
+ "etherparse",
  "pcap",
 ]
 
@@ -393,6 +444,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,8 @@ dependencies = [
 [[package]]
 name = "sniffnet-packet-parser"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f13883bd61e7b4055166b07087c845a3f47b5a42d8e9784c2ec41a04b5a158c"
 dependencies = [
  "etherparse",
  "pcap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4.6.6", features = ["derive"] }
 pcap = "2.5.0"
 log = "0.4.34"
 jiff = "0.2.35"
-sniffnet-packet-parser = { path = "../sniffnet/lib/sniffnet-packet-parser" }
+sniffnet-packet-parser = "0.1.0"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ print_stdout = "warn"
 print_stderr = "warn"
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
-etherparse = "0.20.1"
-pcap = "2.4.0"
-log = "0.4.30"
-jiff = "0.2.27"
+clap = { version = "4.6.6", features = ["derive"] }
+pcap = "2.5.0"
+log = "0.4.34"
+jiff = "0.2.35"
+sniffnet-packet-parser = { path = "../sniffnet/lib/sniffnet-packet-parser" }
 
 [profile.release]
 opt-level = 3

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::IpAddr;
 use std::sync::mpsc::Sender;
 use std::time::{Duration, Instant};
 
-use etherparse::{EtherType, LaxPacketHeaders, LinkHeader, NetHeaders, TransportHeader};
-use pcap::{Active, Capture, Linktype};
-
 use crate::cli::Config;
 use crate::flow::{FlowAddrs, FlowKey, FlowTable, FlowVal};
+use pcap::{Active, Capture};
+use sniffnet_packet_parser::{LinkType, ParsedPacket};
 
 struct Decoded {
     key: FlowKey,
@@ -16,11 +15,11 @@ struct Decoded {
     dst_mac: Option<[u8; 6]>,
 }
 
-pub fn open(cfg: &Config) -> Result<(Capture<Active>, Linktype), pcap::Error> {
+pub fn open(cfg: &Config) -> Result<(Capture<Active>, LinkType), pcap::Error> {
     let cap = open_capture(cfg)?;
-    let link_type = cap.get_datalink();
-    let lt_label = link_type_label(link_type);
-    if !link_type_is_supported(link_type) {
+    let link_type = LinkType::from_pcap(cap.get_datalink());
+    let lt_label = link_type.description();
+    if !link_type.is_supported() {
         log::warn!(
             "unsupported link type '{lt_label}' on '{}'; decoding as Ethernet",
             cfg.interface.name,
@@ -33,15 +32,7 @@ pub fn open(cfg: &Config) -> Result<(Capture<Active>, Linktype), pcap::Error> {
     Ok((cap, link_type))
 }
 
-fn link_type_label(lt: Linktype) -> String {
-    let name = lt.get_name().unwrap_or_else(|_| lt.0.to_string());
-    match lt.get_description() {
-        Ok(desc) => format!("{name} ({desc})"),
-        Err(_) => name,
-    }
-}
-
-pub fn run(mut cap: Capture<Active>, link_type: Linktype, tx: &Sender<HashMap<FlowKey, FlowVal>>) {
+pub fn run(mut cap: Capture<Active>, link_type: LinkType, tx: &Sender<HashMap<FlowKey, FlowVal>>) {
     let mut table = FlowTable::new();
     let interval = Duration::from_millis(900);
     let mut last_drain = Instant::now();
@@ -70,20 +61,6 @@ pub fn run(mut cap: Capture<Active>, link_type: Linktype, tx: &Sender<HashMap<Fl
     }
 }
 
-fn link_type_is_supported(lt: Linktype) -> bool {
-    matches!(
-        lt,
-        Linktype::ETHERNET
-            | Linktype::NULL
-            | Linktype::LOOP
-            | Linktype::IPV4
-            | Linktype::IPV6
-            | Linktype::LINUX_SLL
-            | Linktype::LINUX_SLL2
-            | Linktype(12) // DLT_RAW
-    )
-}
-
 fn open_capture(cfg: &Config) -> Result<Capture<Active>, pcap::Error> {
     let mut cap = Capture::from_device(cfg.interface.clone())?
         .promisc(false)
@@ -103,96 +80,25 @@ fn open_capture(cfg: &Config) -> Result<Capture<Active>, pcap::Error> {
     Ok(cap)
 }
 
-fn get_sniffable_headers(packet: &[u8], link_type: Linktype) -> Option<LaxPacketHeaders<'_>> {
-    match link_type {
-        Linktype::NULL | Linktype::LOOP => from_null(packet),
-        Linktype::LINUX_SLL => from_linux_sll(packet, true),
-        Linktype::LINUX_SLL2 => from_linux_sll(packet, false),
-        Linktype::IPV4 | Linktype::IPV6 | Linktype(12) => LaxPacketHeaders::from_ip(packet).ok(),
-        _ => LaxPacketHeaders::from_ethernet(packet).ok(),
-    }
-}
+fn decode_packet(data: &[u8], link_type: LinkType) -> Option<Decoded> {
+    let parsed = ParsedPacket::from_bytes(data, link_type)?;
 
-fn from_null(packet: &[u8]) -> Option<LaxPacketHeaders<'_>> {
-    if packet.len() <= 4 {
-        return None;
-    }
+    let src_mac = parsed.link_info.src_mac;
+    let dst_mac = parsed.link_info.dst_mac;
 
-    let is_valid_af_inet = {
-        // based on https://wiki.wireshark.org/NullLoopback.md (2023-12-31)
-        fn matches(val: u32) -> bool {
-            match val {
-                // 2 = IPv4 on all platforms
-                // 24, 28, or 30 = IPv6 depending on platform
-                2 | 24 | 28 | 30 => true,
-                _ => false,
-            }
-        }
-        let h = &packet[..4];
-        let b = [h[0], h[1], h[2], h[3]];
-        // check both big endian and little endian representations
-        // as some OS'es use native endianness and others use big endian
-        matches(u32::from_le_bytes(b)) || matches(u32::from_be_bytes(b))
+    let src_ip = parsed.net_info.src_ip;
+    let dst_ip = parsed.net_info.dst_ip;
+    let addrs = match (src_ip, dst_ip) {
+        (IpAddr::V4(src), IpAddr::V4(dst)) => FlowAddrs::V4 { src, dst },
+        (IpAddr::V6(src), IpAddr::V6(dst)) => FlowAddrs::V6 { src, dst },
+        _ => return None,
     };
 
-    if is_valid_af_inet {
-        LaxPacketHeaders::from_ip(&packet[4..]).ok()
-    } else {
-        None
-    }
-}
+    let src_port = parsed.transport_info.src_port;
+    let dst_port = parsed.transport_info.dst_port;
+    let protocol = parsed.transport_info.protocol.number()?;
 
-fn from_linux_sll(packet: &[u8], is_v1: bool) -> Option<LaxPacketHeaders<'_>> {
-    let header_len = if is_v1 { 16 } else { 20 };
-    if packet.len() <= header_len {
-        return None;
-    }
-
-    let protocol_type = u16::from_be_bytes(if is_v1 {
-        [packet[14], packet[15]]
-    } else {
-        [packet[0], packet[1]]
-    });
-    let payload = &packet[header_len..];
-
-    Some(LaxPacketHeaders::from_ether_type(
-        EtherType(protocol_type),
-        payload,
-    ))
-}
-
-fn decode_packet(data: &[u8], link_type: Linktype) -> Option<Decoded> {
-    let headers = get_sniffable_headers(data, link_type)?;
-
-    let (src_mac, dst_mac, link_bytes) = match headers.link {
-        Some(LinkHeader::Ethernet2(eth)) => (Some(eth.source), Some(eth.destination), 14),
-        _ => (None, None, 0),
-    };
-
-    let (addrs, net_bytes) = match headers.net? {
-        NetHeaders::Ipv4(h, _) => (
-            FlowAddrs::V4 {
-                src: Ipv4Addr::from(h.source),
-                dst: Ipv4Addr::from(h.destination),
-            },
-            u64::from(h.total_len),
-        ),
-        NetHeaders::Ipv6(h, _) => (
-            FlowAddrs::V6 {
-                src: Ipv6Addr::from(h.source),
-                dst: Ipv6Addr::from(h.destination),
-            },
-            u64::from(h.payload_length) + 40,
-        ),
-        NetHeaders::Arp(_) => return None,
-    };
-
-    let (src_port, dst_port, protocol) = match headers.transport? {
-        TransportHeader::Tcp(t) => (Some(t.source_port), Some(t.destination_port), 6u8),
-        TransportHeader::Udp(u) => (Some(u.source_port), Some(u.destination_port), 17u8),
-        TransportHeader::Icmpv4(_) => (None, None, 1u8),
-        TransportHeader::Icmpv6(_) => (None, None, 58u8),
-    };
+    let bytes = parsed.bytes_count() as u64;
 
     Some(Decoded {
         key: FlowKey {
@@ -201,7 +107,7 @@ fn decode_packet(data: &[u8], link_type: Linktype) -> Option<Decoded> {
             dst_port,
             protocol,
         },
-        bytes: link_bytes + net_bytes,
+        bytes,
         src_mac,
         dst_mac,
     })

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use pcap::Linktype;
+use sniffnet_packet_parser::LinkType;
 
 /// IPFIX IE 61 `flowDirection` values: 0x00 = ingress, 0x01 = egress.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -46,7 +46,7 @@ pub fn get_direction(
     })
 }
 
-pub fn interface_addresses(interface_name: &str, link_type: Linktype) -> Vec<IpAddr> {
+pub fn interface_addresses(interface_name: &str, link_type: LinkType) -> Vec<IpAddr> {
     let devices = match pcap::Device::list() {
         Ok(d) => d,
         Err(e) => {
@@ -54,7 +54,7 @@ pub fn interface_addresses(interface_name: &str, link_type: Linktype) -> Vec<IpA
             return Vec::new();
         }
     };
-    let is_sll = matches!(link_type, Linktype::LINUX_SLL | Linktype::LINUX_SLL2);
+    let is_sll = matches!(link_type, LinkType::LinuxSll(_) | LinkType::LinuxSll2(_));
     let mut addresses: Vec<IpAddr> = Vec::new();
     let mut matched = false;
     for dev in devices {

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,7 +1,7 @@
+use crate::direction::{FlowDirection, get_direction};
+use sniffnet_packet_parser::Protocol;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
-
-use crate::direction::{FlowDirection, get_direction};
 
 /// Source/destination IPs of a flow, paired by family so mixed-family
 /// [`FlowKey`]s are unrepresentable.
@@ -40,7 +40,7 @@ impl FlowKey {
     /// collector's address+port). Filtered out on the main thread so they
     /// don't appear in the exported stream.
     pub fn is_self_export(&self, collector: SocketAddr) -> bool {
-        self.protocol == 17
+        Some(self.protocol) == Protocol::Udp.number()
             && self.addrs.dst() == collector.ip()
             && self.dst_port == Some(collector.port())
     }

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -40,7 +40,7 @@ impl FlowKey {
     /// collector's address+port). Filtered out on the main thread so they
     /// don't appear in the exported stream.
     pub fn is_self_export(&self, collector: SocketAddr) -> bool {
-        Some(self.protocol) == Protocol::Udp.number()
+        Protocol::from_number(self.protocol) == Some(Protocol::Udp)
             && self.addrs.dst() == collector.ip()
             && self.dst_port == Some(collector.port())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 // TODO: IGMP support
 // TODO: dropped packets
 // TODO: ARP support
-// TODO: adjust Linux SLL parsing once etherparse supports Linux SLL2
 
 mod capture;
 mod cli;


### PR DESCRIPTION
Use the new library `sniffnet-packet-parser` to avoid duplicating network packet parsing code between Sniffnet and `sniffnet-agent`.